### PR TITLE
Revamp Help page into searchable FAQ experience

### DIFF
--- a/app/faq/route.ts
+++ b/app/faq/route.ts
@@ -1,0 +1,9 @@
+import { redirect } from "next/navigation";
+
+export function GET() {
+  redirect("/help");
+}
+
+export function HEAD() {
+  redirect("/help");
+}

--- a/app/help/faqData.ts
+++ b/app/help/faqData.ts
@@ -1,0 +1,106 @@
+export type FAQItem = {
+  id: string;
+  section:
+    | "Getting Started"
+    | "Saving Content"
+    | "Finding & Using Saves"
+    | "Account & Data"
+    | "Contact";
+  question: string;
+  answer: string;
+  keywords?: string[];
+};
+
+export const FAQ_ITEMS: FAQItem[] = [
+  {
+    id: "what-is-savedit",
+    section: "Getting Started",
+    question: "What is SavedIt?",
+    answer:
+      "SavedIt helps you save posts, articles, and links from any app and keep them organized in one place.",
+    keywords: ["overview", "about", "how it works"],
+  },
+  {
+    id: "create-first-collection",
+    section: "Getting Started",
+    question: "How do I create my first collection?",
+    answer:
+      "Tap New Collection in the app, give it a name (for example, Restaurants or Travel), and you're set.",
+    keywords: ["collections", "new", "setup"],
+  },
+  {
+    id: "save-to-savedit",
+    section: "Saving Content",
+    question: "How do I save something to SavedIt?",
+    answer:
+      "In the app where you found the link, tap Share, choose SavedIt, and pick a collection.",
+    keywords: ["share sheet", "save link", "add"],
+  },
+  {
+    id: "add-tags",
+    section: "Saving Content",
+    question: "Can I add tags?",
+    answer: "Yes. Add tags while saving or later when editing a saved item.",
+    keywords: ["metadata", "labels", "organize"],
+  },
+  {
+    id: "find-saved-item",
+    section: "Finding & Using Saves",
+    question: "How do I find something I saved?",
+    answer:
+      "Use Search to look up by title, tag, or the app you saved it from.",
+    keywords: ["search", "filter", "discover"],
+  },
+  {
+    id: "share-with-friends",
+    section: "Finding & Using Saves",
+    question: "Can I share saves with friends?",
+    answer:
+      "Yes — add friends in SavedIt and share collections with them to plan together.",
+    keywords: ["collaboration", "friends", "share"],
+  },
+  {
+    id: "export-data",
+    section: "Account & Data",
+    question: "Can I export my saved data?",
+    answer: "Yes — go to Profile → Export Data to download your saves.",
+    keywords: ["download", "backup", "export"],
+  },
+  {
+    id: "delete-account",
+    section: "Account & Data",
+    question: "How do I delete my account?",
+    answer:
+      "In Profile → Settings, choose Delete Account. You can pick soft delete (pause) or full delete.",
+    keywords: ["remove", "privacy", "account"],
+  },
+  {
+    id: "contact-support",
+    section: "Contact",
+    question: "Need more help?",
+    answer: "Email support@savedit.app — we typically reply within 1–2 business days.",
+    keywords: ["support", "email", "help"],
+  },
+];
+
+export const FAQ_SECTIONS: FAQItem["section"][] = [
+  "Getting Started",
+  "Saving Content",
+  "Finding & Using Saves",
+  "Account & Data",
+  "Contact",
+];
+
+export const FAQ_BY_SECTION: Record<FAQItem["section"], FAQItem[]> = FAQ_SECTIONS.reduce(
+  (acc, section) => {
+    acc[section] = FAQ_ITEMS.filter((item) => item.section === section);
+    return acc;
+  },
+  {
+    "Getting Started": [],
+    "Saving Content": [],
+    "Finding & Using Saves": [],
+    "Account & Data": [],
+    Contact: [],
+  } as Record<FAQItem["section"], FAQItem[]>,
+);

--- a/app/help/metadata.ts
+++ b/app/help/metadata.ts
@@ -1,0 +1,36 @@
+import type { Metadata } from "next";
+import { isProduction } from "@/lib/env";
+
+const title = "Help & FAQs — SavedIt";
+const description = "How to save, organize, and find your content with SavedIt. Tips, FAQs, and support.";
+const canonicalUrl = "https://savedit.app/help";
+
+const metadata: Metadata = {
+  metadataBase: new URL("https://savedit.app"),
+  title,
+  description,
+  alternates: {
+    canonical: canonicalUrl,
+  },
+  openGraph: {
+    title,
+    description,
+    url: canonicalUrl,
+    type: "website",
+    images: [{ url: "/api/og", width: 1200, height: 630, alt: "SavedIt" }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title,
+    description,
+    images: ["/api/og"],
+  },
+  robots: isProduction()
+    ? undefined
+    : {
+        index: false,
+        follow: false,
+      },
+};
+
+export default metadata;

--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -1,18 +1,13 @@
-export const metadata = { title: "Help — SavedIt" };
-export default function HelpPage() {
-  return (
-    <main className="mx-auto max-w-2xl p-6 prose dark:prose-invert">
-      <h1>Help &amp; FAQs</h1>
-      <p><strong>SavedIt</strong> lets you save links from any app and organize them into collections.</p>
-      <h2>Common actions</h2>
-      <ul>
-        <li><strong>Create a collection:</strong> In the app, tap <em>New Collection</em>.</li>
-        <li><strong>Share to SavedIt:</strong> Use the system <em>Share</em> sheet and pick <em>SavedIt</em>.</li>
-        <li><strong>Find it later:</strong> Search by title, tag, or source app.</li>
-      </ul>
-      <hr />
-      <h3>Contact</h3>
-      <p>Support: <a href="mailto:support@savedit.app">support@savedit.app</a></p>
-    </main>
-  );
+import HelpPageClient from "@/components/faq/HelpPageClient";
+import { FAQ_ITEMS } from "./faqData";
+
+export default function HelpPage({
+  searchParams,
+}: {
+  searchParams?: { [key: string]: string | string[] | undefined };
+}) {
+  const initialQueryRaw = searchParams?.q;
+  const initialQuery = Array.isArray(initialQueryRaw) ? initialQueryRaw[0] ?? "" : initialQueryRaw ?? "";
+
+  return <HelpPageClient items={FAQ_ITEMS} initialQuery={initialQuery} initiallyExpandedId={null} />;
 }

--- a/components/faq/FAQ.tsx
+++ b/components/faq/FAQ.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useMemo } from "react";
+import type { FAQItem as FAQItemType } from "@/app/help/faqData";
+import FAQItem from "./FAQItem";
+import { FAQ_SECTIONS } from "@/app/help/faqData";
+
+export type FAQProps = {
+  items: FAQItemType[];
+  expandedIds: string[];
+  onToggle: (id: string) => void;
+};
+
+export default function FAQ({ items, expandedIds, onToggle }: FAQProps) {
+  const grouped = useMemo(() => {
+    return items.reduce<Record<string, FAQItemType[]>>((acc, item) => {
+      if (!acc[item.section]) {
+        acc[item.section] = [];
+      }
+      acc[item.section].push(item);
+      return acc;
+    }, {});
+  }, [items]);
+
+  return (
+    <div className="mx-auto max-w-3xl px-4 pb-12 sm:px-6 lg:px-8">
+      <div className="divide-y divide-line/60 overflow-hidden rounded-3xl border border-line/60 bg-white/80 shadow-soft dark:divide-white/10 dark:border-white/10 dark:bg-white/5 dark:shadow-softdark">
+        {FAQ_SECTIONS.map((section) => {
+          const sectionItems = grouped[section] ?? [];
+          if (sectionItems.length === 0) {
+            return null;
+          }
+
+          return (
+            <section key={section} className="px-6 py-6 sm:px-8">
+              <header className="mb-4 flex items-center justify-between gap-4">
+                <h2 className="text-lg font-semibold tracking-tight text-text-light dark:text-white">{section}</h2>
+                <span className="rounded-full border border-emerald-500/30 px-3 py-1 text-xs font-medium text-emerald-600 dark:border-emerald-300/40 dark:text-emerald-300">
+                  {sectionItems.length}
+                </span>
+              </header>
+              <div>
+                {sectionItems.map((item) => (
+                  <FAQItem
+                    key={item.id}
+                    item={item}
+                    isOpen={expandedIds.includes(item.id)}
+                    onToggle={onToggle}
+                  />
+                ))}
+              </div>
+            </section>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/components/faq/FAQItem.tsx
+++ b/components/faq/FAQItem.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import type { FAQItem as FAQItemType } from "@/app/help/faqData";
+
+export type FAQItemProps = {
+  item: FAQItemType;
+  isOpen: boolean;
+  onToggle: (id: string) => void;
+};
+
+export default function FAQItem({ item, isOpen, onToggle }: FAQItemProps) {
+  const regionId = `faq-panel-${item.id}`;
+  const buttonId = `faq-trigger-${item.id}`;
+
+  return (
+    <article id={`faq-${item.id}`} className="border-b border-line/60 last:border-b-0 dark:border-line/40">
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        aria-controls={regionId}
+        id={buttonId}
+        onClick={() => onToggle(item.id)}
+        className="flex w-full items-center justify-between gap-4 py-4 text-left text-base font-medium transition-colors hover:text-emerald-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 dark:hover:text-emerald-400"
+      >
+        <span className="leading-tight">{item.question}</span>
+        <span
+          aria-hidden
+          className={`flex h-8 w-8 items-center justify-center rounded-full border border-line/80 text-sm transition-transform duration-200 dark:border-line/50 ${
+            isOpen ? "bg-emerald-500/10 text-emerald-500 rotate-45 dark:bg-emerald-400/10 dark:text-emerald-300" : "text-text-dim"
+          }`}
+        >
+          +
+        </span>
+      </button>
+      <div
+        id={regionId}
+        role="region"
+        aria-labelledby={buttonId}
+        className={`grid transform-gpu transition-all duration-200 ease-out ${
+          isOpen ? "grid-rows-[1fr] opacity-100" : "grid-rows-[0fr] opacity-0"
+        }`}
+      >
+        <div className="overflow-hidden pb-4 text-sm leading-relaxed text-text-dim dark:text-text-dark/80">
+          <p>{item.answer}</p>
+        </div>
+      </div>
+    </article>
+  );
+}

--- a/components/faq/HelpHero.tsx
+++ b/components/faq/HelpHero.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+export type HelpHeroProps = {
+  inputValue: string;
+  onInputChange: (value: string) => void;
+  resultsCount: number;
+};
+
+export default function HelpHero({ inputValue, onInputChange, resultsCount }: HelpHeroProps) {
+  const [isMounted, setIsMounted] = useState(false);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  return (
+    <section className="mx-auto max-w-3xl px-4 pb-10 pt-12 sm:px-6 lg:px-8">
+      <div className="space-y-6 rounded-3xl border border-line/60 bg-white/70 p-8 shadow-soft backdrop-blur dark:border-white/10 dark:bg-white/5 dark:shadow-softdark">
+        <div className="space-y-4">
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-500 dark:text-emerald-300">
+            Support Center
+          </p>
+          <h1 className="text-3xl font-semibold tracking-tight text-text-light dark:text-white sm:text-4xl">
+            Help & FAQs
+          </h1>
+          <p className="max-w-2xl text-base text-text-dim dark:text-text-dark/80">
+            Welcome to SavedIt! Here’s a quick guide to get the most out of your saved content.
+          </p>
+        </div>
+        <label className="group block">
+          <span className="sr-only">Search FAQs</span>
+          <div className="relative">
+            <svg
+              className="pointer-events-none absolute left-4 top-1/2 h-5 w-5 -translate-y-1/2 text-text-dim/80 dark:text-text-dark/70"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="1.8"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden
+            >
+              <circle cx="11" cy="11" r="7" />
+              <line x1="16.65" y1="16.65" x2="21" y2="21" />
+            </svg>
+            <input
+              type="search"
+              aria-label="Search FAQs"
+              placeholder="Search by question, feature, or keyword"
+              value={inputValue}
+              onChange={(event) => onInputChange(event.target.value)}
+              className="w-full rounded-2xl border border-line/70 bg-white/90 py-4 pl-12 pr-4 text-base text-text-light transition focus:border-emerald-500 focus:outline-none focus:ring-4 focus:ring-emerald-500/20 dark:border-white/15 dark:bg-white/10 dark:text-white dark:placeholder:text-text-dark/60"
+              autoComplete="off"
+              enterKeyHint="search"
+            />
+          </div>
+          {isMounted && (
+            <p className="mt-2 text-sm text-text-dim dark:text-text-dark/70">
+              {resultsCount === 1 ? "Showing 1 result" : `Showing ${resultsCount} results`}
+            </p>
+          )}
+        </label>
+      </div>
+    </section>
+  );
+}

--- a/components/faq/HelpPageClient.tsx
+++ b/components/faq/HelpPageClient.tsx
@@ -1,0 +1,185 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import type { FAQItem } from "@/app/help/faqData";
+import HelpHero from "./HelpHero";
+import FAQ from "./FAQ";
+import { trackEvent } from "@/lib/analytics";
+
+const SEARCH_DEBOUNCE_MS = 160;
+
+function useDebouncedValue<T>(value: T, delay: number) {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handle = window.setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      window.clearTimeout(handle);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+}
+
+function normalizeQuery(value: string) {
+  return value.trim().toLowerCase();
+}
+
+export type HelpPageClientProps = {
+  items: FAQItem[];
+  initialQuery?: string;
+  initiallyExpandedId?: string | null;
+};
+
+export default function HelpPageClient({ items, initialQuery = "", initiallyExpandedId }: HelpPageClientProps) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const [inputValue, setInputValue] = useState(initialQuery);
+  const [expandedIds, setExpandedIds] = useState<string[]>(() =>
+    initiallyExpandedId ? [initiallyExpandedId] : [],
+  );
+  const debouncedQuery = useDebouncedValue(inputValue, SEARCH_DEBOUNCE_MS);
+  const latestTrackedQuery = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!initiallyExpandedId) {
+      return;
+    }
+    setExpandedIds((prev) => (prev.includes(initiallyExpandedId) ? prev : [...prev, initiallyExpandedId]));
+    const element = document.getElementById(`faq-${initiallyExpandedId}`);
+    if (element) {
+      element.scrollIntoView({ behavior: "smooth", block: "start" });
+    }
+  }, [initiallyExpandedId]);
+
+  useEffect(() => {
+    const applyHash = () => {
+      const hash = window.location.hash.slice(1);
+      if (hash.startsWith("faq-")) {
+        const id = hash.replace("faq-", "");
+        setExpandedIds((prev) => (prev.includes(id) ? prev : [...prev, id]));
+        const element = document.getElementById(`faq-${id}`);
+        if (element) {
+          element.scrollIntoView({ behavior: "smooth", block: "start" });
+        }
+      }
+    };
+
+    applyHash();
+    window.addEventListener("hashchange", applyHash);
+    return () => window.removeEventListener("hashchange", applyHash);
+  }, []);
+
+  const query = useMemo(() => normalizeQuery(debouncedQuery), [debouncedQuery]);
+
+  const filteredItems = useMemo(() => {
+    if (query.length < 2) {
+      return items;
+    }
+    return items.filter((item) => {
+      const haystack = [item.question, item.answer, ...(item.keywords ?? [])]
+        .join(" ")
+        .toLowerCase();
+      return haystack.includes(query);
+    });
+  }, [items, query]);
+
+  const handleToggle = useCallback(
+    (id: string) => {
+      setExpandedIds((prev) => {
+        const isOpen = prev.includes(id);
+        const next = isOpen ? prev.filter((itemId) => itemId !== id) : [...prev, id];
+        if (!isOpen) {
+          trackEvent("help_faq_open", { id, section: items.find((item) => item.id === id)?.section });
+        }
+        return next;
+      });
+      if (typeof window !== "undefined") {
+        const newHash = `#faq-${id}`;
+        if (window.location.hash !== newHash) {
+          history.replaceState(null, "", `${window.location.pathname}${window.location.search}${newHash}`);
+        }
+      }
+    },
+    [items],
+  );
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+    const currentParams = new URLSearchParams(searchParams?.toString() ?? "");
+    if (debouncedQuery && normalizeQuery(debouncedQuery).length >= 2) {
+      currentParams.set("q", debouncedQuery);
+    } else {
+      currentParams.delete("q");
+    }
+    const queryString = currentParams.toString();
+    if (queryString === (searchParams?.toString() ?? "")) {
+      return;
+    }
+    router.replace(`${pathname}${queryString ? `?${queryString}` : ""}${window.location.hash}`, { scroll: false });
+  }, [debouncedQuery, pathname, router, searchParams]);
+
+  useEffect(() => {
+    const normalized = normalizeQuery(debouncedQuery);
+    if (latestTrackedQuery.current === normalized) {
+      return;
+    }
+    latestTrackedQuery.current = normalized;
+    trackEvent("help_search", { query_length: normalized.length, ts: Date.now() });
+  }, [debouncedQuery]);
+
+  const onInputChange = useCallback((value: string) => {
+    setInputValue(value);
+  }, []);
+
+  const resultsCount = filteredItems.length;
+
+  return (
+    <div className="pb-24">
+      <HelpHero inputValue={inputValue} onInputChange={onInputChange} resultsCount={resultsCount} />
+      {resultsCount > 0 ? (
+        <FAQ items={filteredItems} expandedIds={expandedIds} onToggle={handleToggle} />
+      ) : (
+        <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+          <div className="rounded-3xl border border-dashed border-emerald-400/60 bg-emerald-500/5 p-10 text-center dark:border-emerald-300/50 dark:bg-emerald-400/10">
+            <h2 className="text-xl font-semibold text-text-light dark:text-white">No results for “{debouncedQuery}”.</h2>
+            <p className="mt-3 text-base text-text-dim dark:text-text-dark/80">
+              Try a different keyword or email us at {" "}
+              <a
+                className="font-medium text-emerald-600 underline decoration-emerald-300/70 underline-offset-4 transition hover:text-emerald-500 dark:text-emerald-300 dark:hover:text-emerald-200"
+                href="mailto:support@savedit.app"
+              >
+                support@savedit.app
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      )}
+      <aside className="mx-auto mt-16 max-w-3xl px-4 sm:px-6 lg:px-8">
+        <div className="flex flex-col items-start gap-4 rounded-3xl border border-emerald-500/30 bg-emerald-500/10 p-8 text-left shadow-soft dark:border-emerald-300/30 dark:bg-emerald-400/10 dark:shadow-softdark">
+          <div>
+            <h2 className="text-lg font-semibold text-text-light dark:text-white">Still stuck?</h2>
+            <p className="mt-2 text-base text-text-dim dark:text-text-dark/80">
+              Email our support team and we’ll help you get back to saving smarter.
+            </p>
+          </div>
+          <a
+            href="mailto:support@savedit.app"
+            className="inline-flex items-center gap-2 rounded-full bg-text-light px-5 py-2 text-sm font-semibold text-white transition hover:bg-text-light/90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-emerald-500 dark:bg-white/90 dark:text-text-light"
+          >
+            Contact support
+            <span aria-hidden className="text-lg leading-none">→</span>
+          </a>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/docs/HELP_PAGE_NOTES.md
+++ b/docs/HELP_PAGE_NOTES.md
@@ -1,0 +1,34 @@
+# Help Page Notes
+
+## Content source of truth
+- FAQ entries live in [`app/help/faqData.ts`](../app/help/faqData.ts). Marketing can edit the array without touching any JSX.
+- Each entry must include an `id`, `section`, `question`, `answer`, and optional `keywords` for search relevance.
+
+## Editing or adding FAQs
+1. Duplicate an existing object in `FAQ_ITEMS` and adjust the text.
+2. Ensure the `id` stays unique and URL friendly (used for hash links like `#faq-what-is-savedit`).
+3. Pick one of the supported sections defined in `FAQItem["section"]`.
+4. Optionally extend `keywords` with short strings to improve search results.
+
+When new sections are required, update both `FAQ_SECTIONS` and the derived `FAQ_BY_SECTION` map so the UI renders in the right order.
+
+## Search behavior
+- The search input filters FAQs on the client after a 160ms debounce.
+- Queries shorter than two characters keep all FAQs visible to encourage exploration.
+- Matching looks at the question, answer, and any `keywords` values.
+- When no matches are found, a highlighted state invites the visitor to email support.
+- Search terms are synced to the URL (`?q=...`) so deep links retain context.
+
+## Linking to a specific question
+- Each question renders with an anchor ID following `faq-{id}`.
+- Linking directly to `/help#faq-export-data` opens the accordion automatically and scrolls it into view.
+- Hash changes continue to work thanks to a listener that expands and focuses the relevant item.
+
+## Analytics
+- Opening a question emits `help_faq_open` with the FAQ `id` and `section`.
+- Search updates emit `help_search` with the normalized query length and a timestamp.
+- Events currently pass through a no-op helper in [`lib/analytics.ts`](../lib/analytics.ts); connect this to Vercel Analytics or PostHog when ready.
+
+## Follow-ups / TODOs
+- Replace the analytics no-op with the production tracking client once available.
+- If SavedIt gains additional sections, consider promoting them to dedicated components for layout reuse.

--- a/lib/analytics.ts
+++ b/lib/analytics.ts
@@ -1,0 +1,8 @@
+// TODO: Wire this helper to the production analytics provider (e.g., Vercel Analytics or PostHog).
+// For now it is a no-op so that components can safely invoke it without runtime errors.
+export function trackEvent(event: string, payload?: Record<string, unknown>) {
+  if (process.env.NODE_ENV !== "production") {
+    // Uncomment to debug in development:
+    // console.debug(`[analytics] ${event}`, payload);
+  }
+}

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,7 @@
+export function isProduction() {
+  return process.env.VERCEL_ENV === "production";
+}
+
+export function getVercelEnv() {
+  return process.env.VERCEL_ENV ?? "";
+}


### PR DESCRIPTION
## Summary
- replace the Help page with a polished FAQ experience including hero search, grouped accordions, URL sync, and contact CTA
- centralize FAQ copy in a typed data source and document how to manage it for marketing
- add SEO metadata, /faq redirect, and lightweight env/analytics helpers to support canonical + tracking needs

## Testing
- npm run lint *(fails: Next.js prompts for initial ESLint configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7c2dc238832e9f140a8eebef44c6