### PR TITLE
Improve SEO metadata and social sharing previews

### DIFF
--- a/app/help/page.tsx
+++ b/app/help/page.tsx
@@ -1,18 +1,37 @@
-export const metadata = { title: "Help — SavedIt" };
+import type { Metadata } from "next";
+import { createPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Help & FAQs",
+  description:
+    "Get quick answers about creating collections, saving links, and contacting the SavedIt team for support.",
+  path: "/help",
+});
+
 export default function HelpPage() {
   return (
     <main className="mx-auto max-w-2xl p-6 prose dark:prose-invert">
       <h1>Help &amp; FAQs</h1>
-      <p><strong>SavedIt</strong> lets you save links from any app and organize them into collections.</p>
+      <p>
+        <strong>SavedIt</strong> lets you save links from any app and organize them into collections.
+      </p>
       <h2>Common actions</h2>
       <ul>
-        <li><strong>Create a collection:</strong> In the app, tap <em>New Collection</em>.</li>
-        <li><strong>Share to SavedIt:</strong> Use the system <em>Share</em> sheet and pick <em>SavedIt</em>.</li>
-        <li><strong>Find it later:</strong> Search by title, tag, or source app.</li>
+        <li>
+          <strong>Create a collection:</strong> In the app, tap <em>New Collection</em>.
+        </li>
+        <li>
+          <strong>Share to SavedIt:</strong> Use the system <em>Share</em> sheet and pick <em>SavedIt</em>.
+        </li>
+        <li>
+          <strong>Find it later:</strong> Search by title, tag, or source app.
+        </li>
       </ul>
       <hr />
       <h3>Contact</h3>
-      <p>Support: <a href="mailto:support@savedit.app">support@savedit.app</a></p>
+      <p>
+        Support: <a href="mailto:support@savedit.app">support@savedit.app</a>
+      </p>
     </main>
   );
 }

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,25 +2,20 @@ import type { Metadata } from "next";
 import "./globals.css";
 import AppThemeProvider from "@/src/components/AppThemeProvider";
 import Header from "@/components/Header";
+import { baseMetadata, structuredData } from "@/lib/seo";
 
-export const metadata: Metadata = {
-  title: "SavedIt",
-  description: "One place for all your saves.",
-  icons: {
-    icon: "/adaptive-icon.png",
-    apple: "/adaptive-icon.png",
-    shortcut: "/adaptive-icon.png",
-  },
-  openGraph: {
-    title: "SavedIt",
-    description: "One place for all your saves.",
-    images: [{ url: "/api/og", width: 1200, height: 630, alt: "SavedIt" }],
-  },
-};
+export const metadata: Metadata = baseMetadata;
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en" suppressHydrationWarning>
+      <head>
+        <script
+          key="savedit-structured-data"
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(structuredData) }}
+        />
+      </head>
       <body>
         <AppThemeProvider>
           <div id="app-fade-root">

--- a/app/legal/privacy/page.tsx
+++ b/app/legal/privacy/page.tsx
@@ -1,9 +1,21 @@
-export const metadata = { title: "Privacy — SavedIt" };
+import type { Metadata } from "next";
+import { createPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Privacy Policy",
+  description:
+    "Understand how SavedIt handles account details, saved content, and data deletion requests with a privacy-first approach.",
+  path: "/legal/privacy",
+});
+
 export default function PrivacyPage() {
   return (
     <main className="mx-auto max-w-2xl p-6 prose dark:prose-invert">
       <h1>Privacy Policy</h1>
-      <p>We collect minimal data to run SavedIt (account + saved links). We do not sell your data. You can request deletion at any time.</p>
+      <p>
+        We collect minimal data to run SavedIt (account + saved links). We do not sell your data. You can request deletion at any
+        time.
+      </p>
       <h2>What we store</h2>
       <ul>
         <li>Account info (email, name)</li>
@@ -13,9 +25,13 @@ export default function PrivacyPage() {
       <h2>Your choices</h2>
       <ul>
         <li>Export or delete your data from <em>Settings</em> in the app.</li>
-        <li>Contact <a href="mailto:privacy@savedit.app">privacy@savedit.app</a> for requests.</li>
+        <li>
+          Contact <a href="mailto:privacy@savedit.app">privacy@savedit.app</a> for requests.
+        </li>
       </ul>
-      <p><small>Last updated: September 2025</small></p>
+      <p>
+        <small>Last updated: September 2025</small>
+      </p>
     </main>
   );
 }

--- a/app/legal/terms/page.tsx
+++ b/app/legal/terms/page.tsx
@@ -1,16 +1,29 @@
-export const metadata = { title: "Terms — SavedIt" };
+import type { Metadata } from "next";
+import { createPageMetadata } from "@/lib/seo";
+
+export const metadata: Metadata = createPageMetadata({
+  title: "Terms of Service",
+  description:
+    "Review the SavedIt terms of service covering user responsibilities, content ownership, and future updates to the platform.",
+  path: "/legal/terms",
+});
+
 export default function TermsPage() {
   return (
     <main className="mx-auto max-w-2xl p-6 prose dark:prose-invert">
       <h1>Terms of Service</h1>
-      <p><em>By using SavedIt, you agree to these terms.</em></p>
+      <p>
+        <em>By using SavedIt, you agree to these terms.</em>
+      </p>
       <ol>
         <li>You retain rights to your content.</li>
         <li>Don't upload illegal or harmful content.</li>
         <li>Service is provided "as is," without warranties.</li>
         <li>We may update these terms; continued use means acceptance.</li>
       </ol>
-      <p><small>Last updated: September 2025</small></p>
+      <p>
+        <small>Last updated: September 2025</small>
+      </p>
     </main>
   );
 }

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,25 +1,166 @@
-import type { Metadata } from 'next'
+import type { Metadata } from "next";
 
-const title = 'SavedIt — Turn saved posts into plans'
-const description = 'SavedIt gathers your saved reels, links, and ideas, enriches them with smart metadata, and turns them into beautifully organized, actionable cards.'
-const url = 'https://savedit.app'
+const fallbackSiteUrl = "https://savedit.app";
+const siteName = "SavedIt";
+const baseTagline = "Save once. Find forever.";
+
+export const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? fallbackSiteUrl;
+const normalizedSiteUrl = siteUrl.endsWith("/") ? siteUrl.slice(0, -1) : siteUrl;
+
+export const absoluteUrl = (path = ""): string => {
+  if (!path) {
+    return normalizedSiteUrl;
+  }
+
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const prefixed = path.startsWith("/") ? path : `/${path}`;
+  return `${normalizedSiteUrl}${prefixed}`;
+};
+
+const defaultTitle = `${siteName} — ${baseTagline}`;
+const titleTemplate = "%s — SavedIt";
+export const siteDescription =
+  "SavedIt gathers your saved reels, links, and ideas, enriches them with smart metadata, and turns them into beautifully organized, actionable cards.";
+
+const keywords = [
+  "SavedIt",
+  "save links",
+  "bookmark manager",
+  "organize saved posts",
+  "reading list app",
+  "link collections",
+  "personal knowledge base",
+  "productivity",
+  "offline saves",
+];
+
+const ogImage = absoluteUrl("/api/og");
 
 export const baseMetadata: Metadata = {
-  metadataBase: new URL(url),
-  title,
-  description,
+  metadataBase: new URL(normalizedSiteUrl),
+  title: {
+    default: defaultTitle,
+    template: titleTemplate,
+  },
+  description: siteDescription,
+  keywords,
+  applicationName: siteName,
+  category: "Productivity",
+  creator: siteName,
+  publisher: siteName,
+  authors: [{ name: "SavedIt Team" }],
+  alternates: {
+    canonical: normalizedSiteUrl,
+  },
   openGraph: {
-    title,
-    description,
-    url,
-    type: 'website',
-    images: [{ url: '/api/og', width: 1200, height: 630, alt: 'SavedIt' }]
+    type: "website",
+    url: normalizedSiteUrl,
+    title: defaultTitle,
+    description: siteDescription,
+    siteName,
+    locale: "en_US",
+    images: [
+      {
+        url: ogImage,
+        width: 1200,
+        height: 630,
+        alt: "SavedIt hero preview",
+      },
+    ],
   },
   twitter: {
-    card: 'summary_large_image',
-    title,
-    description,
-    images: ['/api/og']
+    card: "summary_large_image",
+    title: defaultTitle,
+    description: siteDescription,
+    images: [ogImage],
   },
-  icons: { icon: '/favicon.png' }
-}
+  icons: {
+    icon: "/favicon.png",
+    shortcut: "/favicon.png",
+    apple: "/adaptive-icon.png",
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
+  themeColor: "#ffffff",
+};
+
+export type PageMetadataOptions = {
+  title: string;
+  description?: string;
+  path?: string;
+  image?: string;
+};
+
+export const createPageMetadata = ({
+  title,
+  description,
+  path,
+  image,
+}: PageMetadataOptions): Metadata => {
+  const pageDescription = description ?? siteDescription;
+  const canonicalUrl = path ? absoluteUrl(path) : normalizedSiteUrl;
+  const socialImage = image ? absoluteUrl(image) : ogImage;
+
+  return {
+    title,
+    description: pageDescription,
+    alternates: {
+      canonical: canonicalUrl,
+    },
+    openGraph: {
+      type: "website",
+      siteName,
+      title,
+      description: pageDescription,
+      url: canonicalUrl,
+      images: [
+        {
+          url: socialImage,
+          width: 1200,
+          height: 630,
+          alt: "SavedIt hero preview",
+        },
+      ],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description: pageDescription,
+      images: [socialImage],
+    },
+  } satisfies Metadata;
+};
+
+export const structuredData = {
+  "@context": "https://schema.org",
+  "@type": "SoftwareApplication",
+  name: siteName,
+  url: normalizedSiteUrl,
+  applicationCategory: "ProductivityApplication",
+  operatingSystem: "iOS, Android, Web",
+  description: siteDescription,
+  image: ogImage,
+  publisher: {
+    "@type": "Organization",
+    name: siteName,
+    url: normalizedSiteUrl,
+    logo: absoluteUrl("/adaptive-icon.png"),
+  },
+  offers: {
+    "@type": "Offer",
+    price: "0",
+    priceCurrency: "USD",
+  },
+};


### PR DESCRIPTION
## Summary
- centralize SavedIt SEO defaults with canonical URLs, Open Graph/Twitter configuration, and structured data for share previews
- apply descriptive page metadata across help and legal pages so shared links surface rich titles, descriptions, and imagery

## Testing
- npm run lint *(fails: Next.js prompts for initial ESLint configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68dd7fd276b8832e9f533e95b91221a2